### PR TITLE
OpenCms 10.0.0 Java 8 and Java 7

### DIFF
--- a/com.alkacon.opencms.documentation.content/resources/opencms-documentation/.content/documentation-section/documentation-section-00329.xml
+++ b/com.alkacon.opencms.documentation.content/resources/opencms-documentation/.content/documentation-section/documentation-section-00329.xml
@@ -2,7 +2,7 @@
 
 <DocumentationSections xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="opencms://system/modules/com.alkacon.opencms.documentation/schemas/documentation-section.xsd">
   <DocumentationSection language="en">
-    <Headline><![CDATA[Install the Java SDK, version 6 or newer]]></Headline>
+    <Headline><![CDATA[Install the Java SDK, version 7 or newer]]></Headline>
     <VersionInfo/>
     <DocuVersionInfo/>
     <StatusMetaData>


### PR DESCRIPTION
http://www.opencms.org/en/news/160323-opencms-v1000-releasenotes.html

"OpenCms 10.0.0 has been written and tested for Java 8 and Java 7. We have tested with ORACLEs JDK as well as OpenJDK. OpenCms should run with all compliant JVMs."
